### PR TITLE
Add placeholder menu pages and navigation

### DIFF
--- a/account.html
+++ b/account.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+  <title>Cuenta - RodoShop</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <div class="header-left">
+      <div class="header-logo">RodoShop</div>
+    </div>
+    <div class="search-bar">
+      <input type="text" placeholder="Buscar productos...">
+    </div>
+    <div class="header-right">
+      <a href="cart.html" class="cart-icon" style="color:white;">
+        <i class="fa fa-shopping-cart"></i>
+        <span class="count">0</span>
+      </a>
+      <div class="header-text">
+        <a href="index.html" style="color:white; text-decoration:none;">Inicio</a>
+        <a href="categories.html" style="color:white; text-decoration:none;">Categorías</a>
+        <a href="account.html" style="color:white; text-decoration:none;">Cuenta</a>
+      </div>
+    </div>
+  </header>
+
+  <main style="padding:16px;">
+    <h1>Cuenta</h1>
+    <p>Información de la cuenta en construcción.</p>
+  </main>
+
+  <footer class="footer-mobile">
+    <a href="index.html"><i class="fa fa-home"></i>Inicio</a>
+    <a href="categories.html"><i class="fa fa-list"></i>Categorías</a>
+    <a href="cart.html"><i class="fa fa-shopping-cart"></i>Carrito</a>
+    <a href="account.html"><i class="fa fa-user"></i>Cuenta</a>
+  </footer>
+
+  <script type="module">
+    import { updateCartCount } from './render.js';
+    document.addEventListener('DOMContentLoaded', () => {
+      const countEl = document.querySelector('.cart-icon .count');
+      updateCartCount(countEl);
+    });
+  </script>
+</body>
+</html>

--- a/cart.html
+++ b/cart.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+  <title>Carrito - RodoShop</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <div class="header-left">
+      <div class="header-logo">RodoShop</div>
+    </div>
+    <div class="search-bar">
+      <input type="text" placeholder="Buscar productos...">
+    </div>
+    <div class="header-right">
+      <a href="cart.html" class="cart-icon" style="color:white;">
+        <i class="fa fa-shopping-cart"></i>
+        <span class="count">0</span>
+      </a>
+      <div class="header-text">
+        <a href="index.html" style="color:white; text-decoration:none;">Inicio</a>
+        <a href="categories.html" style="color:white; text-decoration:none;">Categorías</a>
+        <a href="account.html" style="color:white; text-decoration:none;">Cuenta</a>
+      </div>
+    </div>
+  </header>
+
+  <main style="padding:16px;">
+    <h1>Carrito</h1>
+    <p>Tu carrito está vacío por ahora.</p>
+  </main>
+
+  <footer class="footer-mobile">
+    <a href="index.html"><i class="fa fa-home"></i>Inicio</a>
+    <a href="categories.html"><i class="fa fa-list"></i>Categorías</a>
+    <a href="cart.html"><i class="fa fa-shopping-cart"></i>Carrito</a>
+    <a href="account.html"><i class="fa fa-user"></i>Cuenta</a>
+  </footer>
+
+  <script type="module">
+    import { updateCartCount } from './render.js';
+    document.addEventListener('DOMContentLoaded', () => {
+      const countEl = document.querySelector('.cart-icon .count');
+      updateCartCount(countEl);
+    });
+  </script>
+</body>
+</html>

--- a/categories.html
+++ b/categories.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+  <title>Categorías - RodoShop</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <div class="header-left">
+      <div class="header-logo">RodoShop</div>
+    </div>
+    <div class="search-bar">
+      <input type="text" placeholder="Buscar productos...">
+    </div>
+    <div class="header-right">
+      <a href="cart.html" class="cart-icon" style="color:white;">
+        <i class="fa fa-shopping-cart"></i>
+        <span class="count">0</span>
+      </a>
+      <div class="header-text">
+        <a href="index.html" style="color:white; text-decoration:none;">Inicio</a>
+        <a href="categories.html" style="color:white; text-decoration:none;">Categorías</a>
+        <a href="account.html" style="color:white; text-decoration:none;">Cuenta</a>
+      </div>
+    </div>
+  </header>
+
+  <main style="padding:16px;">
+    <h1>Categorías</h1>
+    <ul style="margin-top:10px; list-style:none; padding:0;">
+      <li>Electrónica</li>
+      <li>Ropa</li>
+      <li>Hogar</li>
+      <li>Ofertas</li>
+      <li>Zapatos</li>
+    </ul>
+  </main>
+
+  <footer class="footer-mobile">
+    <a href="index.html"><i class="fa fa-home"></i>Inicio</a>
+    <a href="categories.html"><i class="fa fa-list"></i>Categorías</a>
+    <a href="cart.html"><i class="fa fa-shopping-cart"></i>Carrito</a>
+    <a href="account.html"><i class="fa fa-user"></i>Cuenta</a>
+  </footer>
+
+  <script type="module">
+    import { updateCartCount } from './render.js';
+    document.addEventListener('DOMContentLoaded', () => {
+      const countEl = document.querySelector('.cart-icon .count');
+      updateCartCount(countEl);
+    });
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -192,16 +192,16 @@
 
     <div class="header-right">
       <!-- Carrito visible en móvil y escritorio con cantidad -->
-      <a href="#" class="cart-icon" style="color:white;">
+      <a href="cart.html" class="cart-icon" style="color:white;">
         <i class="fa fa-shopping-cart"></i>
         <span class="count">0</span>
       </a>
 
       <!-- En PC: texto -->
       <div class="header-text">
-        <a href="#" style="color:white; text-decoration:none;">Inicio</a>
-        <a href="#" style="color:white; text-decoration:none;">Categorías</a>
-        <a href="#" style="color:white; text-decoration:none;">Cuenta</a>
+        <a href="index.html" style="color:white; text-decoration:none;">Inicio</a>
+        <a href="categories.html" style="color:white; text-decoration:none;">Categorías</a>
+        <a href="account.html" style="color:white; text-decoration:none;">Cuenta</a>
       </div>
     </div>
   </header>
@@ -227,10 +227,10 @@
   <section class="productos"></section>
 
   <footer class="footer-mobile">
-    <a href="#"><i class="fa fa-home"></i>Inicio</a>
-    <a href="#"><i class="fa fa-list"></i>Categorías</a>
-    <a href="#"><i class="fa fa-shopping-cart"></i>Carrito</a>
-    <a href="#"><i class="fa fa-user"></i>Cuenta</a>
+    <a href="index.html"><i class="fa fa-home"></i>Inicio</a>
+    <a href="categories.html"><i class="fa fa-list"></i>Categorías</a>
+    <a href="cart.html"><i class="fa fa-shopping-cart"></i>Carrito</a>
+    <a href="account.html"><i class="fa fa-user"></i>Cuenta</a>
   </footer>
 
   <script type="module" src="main.js"></script>


### PR DESCRIPTION
## Summary
- Add placeholder pages for Cuenta, Carrito, and Categorías
- Link header and footer navigation to new pages with cart count support

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f8be0619c8327893c929795b76681